### PR TITLE
002usearchive

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,4 +5,4 @@ fixtures:
   forge_modules:
      stdlib: "puppetlabs/stdlib"
      chocolatey: "chocolatey/chocolatey"
-     staging: "puppet/staging"
+     archive: "puppet/archive"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,7 +25,7 @@ class pdk(
       $pdk_complete_download_url = "https://${pdk_download_url}&ver=${pdk_version}"
       $pdk_local_pkg = "pdk-${pdk_version}.${::operatingsystem}${pdk::params::rel}.${pdk::params::pdk_pkg_format}"
 
-      archive { $pdk_local_pkg :
+      archive { "${staging_dir}/${pdk_local_pkg}" :
         source => $pdk_complete_download_url,
       }
       
@@ -33,7 +33,7 @@ class pdk(
         ensure    => $pdk_version,
         provider  => $pdk::params::provider,
         source    => "${staging_dir}/${pdk_local_pkg}",
-        subscribe => Archive[$pdk_local_pkg],
+        subscribe => Archive["${staging_dir}/${pdk_local_pkg}"],
       }
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,7 +28,7 @@ class pdk(
       archive { "${staging_dir}/${pdk_local_pkg}" :
         source => $pdk_complete_download_url,
       }
-      
+
       package {'pdk':
         ensure    => $pdk_version,
         provider  => $pdk::params::provider,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,21 +25,15 @@ class pdk(
       $pdk_complete_download_url = "https://${pdk_download_url}&ver=${pdk_version}"
       $pdk_local_pkg = "pdk-${pdk_version}.${::operatingsystem}${pdk::params::rel}.${pdk::params::pdk_pkg_format}"
 
-      if !defined(Class['staging']){
-        class { '::staging':
-          path  => $staging_dir,
-          #owner => 'puppet',
-          #group => 'puppet',
-        }
-      }
-      staging::file { $pdk_local_pkg :
+      archive { $pdk_local_pkg :
         source => $pdk_complete_download_url,
       }
+      
       package {'pdk':
         ensure    => $pdk_version,
         provider  => $pdk::params::provider,
-        source    => "${staging_dir}/${module_name}/${pdk_local_pkg}",
-        subscribe => Staging::File[$pdk_local_pkg],
+        source    => "${staging_dir}/${pdk_local_pkg}",
+        subscribe => Archive[$pdk_local_pkg],
       }
     }
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,7 +12,7 @@ class pdk::params {
 $staging_dir = '/tmp/staging'
 $base_download_url = 'pm.puppetlabs.com/cgi-bin/pdk_download.cgi?'
 
-$pdk_version = 'installed'
+$pdk_version = 'latest'
   case $facts['operatingsystem'] {
     /^(RedHat|CentOS|Scientific|OracleLinux)$/: {
       $dist = 'el'
@@ -30,8 +30,8 @@ $pdk_version = 'installed'
     }
     'Ubuntu':{
       $dist = 'ubuntu'
-      $rel = $facts[os][release][full]
-      $pdk_download_url = "${base_download_url}dist=${dist}&rel=${rel}&arch=${::architecture}"
+      $rel = $facts['os']['release']['full']
+      $pdk_download_url = "${base_download_url}dist=${dist}&rel=${rel}&arch=${facts['os']['architecture']}"
       $pdk_pkg_format = 'deb'
       $provider = 'dpkg'
     }

--- a/metadata.json
+++ b/metadata.json
@@ -17,7 +17,7 @@
       "version_requirement": ">= 1.2.6"
     },
     {
-      "name": "puppet-staging",
+      "name": "puppet-archive",
       "version_requirement": ">= 3.2.0"
     }
   ],


### PR DESCRIPTION
This module now works on Ubuntu 18.04 with puppet-archive.  I also fixed broken download URLs.

Fixes #2 