### PR TITLE
Adding SLES and Puppet 6/PE 2019 support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,6 +21,13 @@ $pdk_version = 'latest'
       $pdk_pkg_format = 'rpm'
       $provider = 'rpm'
     }
+    'SLES' : {
+      $dist = 'sles'
+      $rel = $facts[operatingsystemmajrelease]
+      $pdk_download_url = "${base_download_url}dist=${dist}&rel=${rel}&arch=${facts['os']['architecture']}"
+      $pdk_pkg_format = 'rpm'
+      $provider = 'rpm'
+    }
     'Darwin' : {
       $dist ='osx'
       $rel = $facts[macosx_productversion_major]

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "abuxton-pdk",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "abuxton",
   "summary": "Module to install the Puppet Development Kit or PDK, created with the pdk... ironically",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -29,6 +29,13 @@
       ]
     },
     {
+      "operatingsystem": "SUSE",
+      "operatingsystemrelease": [
+        "11",
+        "12"
+      ]
+    },
+    {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "16.04"

--- a/metadata.json
+++ b/metadata.json
@@ -82,7 +82,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.7.0 < 6.0.0"
+      "version_requirement": ">= 4.7.0 < 7.0.0"
     }
   ],
   "pdk-version": "1.7.0",


### PR DESCRIPTION
I was able to test this with PE 2019 without any issues and added a couple of lines that allows SLES to be supported.