### PR TITLE
refacter 'operatingsystem' to facts[os][name] to work on puppet8

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,18 +7,17 @@
 #
 # @example
 #   include pdk
-class pdk(
+class pdk (
   Variant[
     String,
     Enum['latest','present','absent','purged','installed']
-    ]               $pdk_version      = $pdk::params::pdk_version,
+  ]               $pdk_version      = $pdk::params::pdk_version,
   Optional[String]  $pdk_download_url = $pdk::params::pdk_download_url,
   Optional[String]  $staging_dir      = $pdk::params::staging_dir,
-  ) inherits pdk::params {
-
-    case $facts['operatingsystem'] {
-      'windows' : {
-        package {'pdk':
+) inherits pdk::params {
+  case $facts['os']['name'] {
+    'windows' : {
+      package { 'pdk':
         ensure   => $pdk_version,
         provider => $pdk::params::provider,
         source   => $pdk_download_url,
@@ -26,13 +25,13 @@ class pdk(
     }
     default: {
       $pdk_complete_download_url = "https://${pdk_download_url}&ver=${pdk_version}"
-      $pdk_local_pkg = "pdk-${pdk_version}.${::operatingsystem}${pdk::params::rel}.${pdk::params::pdk_pkg_format}"
+      $pdk_local_pkg = "pdk-${pdk_version}.${facts['os']['name']}${pdk::params::rel}.${pdk::params::pdk_pkg_format}"
 
       archive { "${staging_dir}/${pdk_local_pkg}" :
         source => $pdk_complete_download_url,
       }
 
-      package {'pdk':
+      package { 'pdk':
         ensure    => $pdk_version,
         provider  => $pdk::params::provider,
         source    => "${staging_dir}/${pdk_local_pkg}",

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,7 +13,7 @@ $staging_dir = '/tmp/staging'
 $base_download_url = 'pm.puppetlabs.com/cgi-bin/pdk_download.cgi?'
 
 $pdk_version = 'latest'
-  case $facts['operatingsystem'] {
+  case $facts['os']['name'] {
     /^(RedHat|CentOS|Scientific|OracleLinux)$/: {
       $dist = 'el'
       $rel = $facts[operatingsystemmajrelease]
@@ -44,7 +44,7 @@ $pdk_version = 'latest'
       $provider = 'chocolatey'
     }
     default :{
-      fail ("${::osfamily} is not supported by the ${module_name} module")
+      fail ("${facts['os']['name']} is not supported by the ${module_name} module")
     }
   }
 


### PR DESCRIPTION
# Pull request

pdk module version 0.2.2 (which is mis-tagged as 0.2.3 in the repo) fails on puppet8 when accessing '::operatingsystem' fact.  These facts were replaced with '$facts[os][name]'.

